### PR TITLE
chore: update ToC page name parsing

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -101,7 +101,9 @@ gulp.task("toc", async () => {
 
     for (const pageToC of ToCs) {
         masterToC.push({
-            content: `[${pageToC.fileName}](${pageToC.fileName})`,
+            content: `[${pageToC.fileName.replace(/_/g, " ")}](${
+                pageToC.fileName
+            })`,
             lvl: 1,
         });
 


### PR DESCRIPTION
Page names with `_` characters will have them replaced by spaces when rendering the Table of Contents.