### PR TITLE
Asset extraction page not found - redirecting to asset information on ONI's Wiki page

### DIFF
--- a/doc/02.Assets/02.Animations/sections/FilesSummary.md
+++ b/doc/02.Assets/02.Animations/sections/FilesSummary.md
@@ -12,7 +12,7 @@ An example of a complete set of animation files:
   This is the file that contains all of the animations for the Printing Pod. (i.e. Keyframes)
 
 The name for an animation does not always match the name you see in the game, so it will be very useful to extract all of the game's textures at once to allow visual searching through the graphics.  
-See [Extracting Assets](Animations#ExtractingAssets) for instructions.
+You can find a comprehensive guide about how to see and extract the assets in [ONI's wiki page](https://oxygennotincluded.fandom.com/wiki/Guide/Working_with_the_Game_Files#Assets)
 
 You can find the texture files for all of the animations in the `<Extracted Assets>/Texture2D` folder.
 


### PR DESCRIPTION
Replacing it with proper information on ONI's wiki.